### PR TITLE
Clean lockfile state upon container startup

### DIFF
--- a/libexec/entrypoint
+++ b/libexec/entrypoint
@@ -4,6 +4,17 @@ set -euo pipefail
 # shellcheck source=share/common.sh
 . $LETSENCRYPT_SHAREDIR/common.sh
 
+# When mounted on an NFS share, file locks don't always handle properly
+# Solution is to delete the pre-existing lock file before container starts up
+# Typical error seen when not doing this is "invalid argument", which prevents dehydrated from doing its thing.
+if [ -f $LETSENCRYPT_DATADIR/get_certificate.pid ]; then
+    rm $LETSENCRYPT_DATADIR/get_certificate.pid
+fi
+# Same goes for the .owner file, an error of "invalid argument" is sometimes caught when trying to modify the file.
+if [ -f /var/lib/www/acme-challenge/.owner ]; then
+    rm /var/lib/www/acme-challenge/.owner
+fi
+
 if [ $# -eq 0 ]; then
     # default command is usage
     set usage


### PR DESCRIPTION
the ``get_certificate.pid`` file generated by dehydrated often cannot be updated upon container startup when the underlying volume is mounted with NFS. The container functions normally after manually deleting the file, so this should be a way to automatically handle clearing the file locks. The cron container still abides by the watcher's status after the lockfile is recreated.